### PR TITLE
Move extruders with G commands 

### DIFF
--- a/cnc/config.py
+++ b/cnc/config.py
@@ -16,10 +16,6 @@ STEPPER_PULSES_PER_MM_Y = 100
 STEPPER_PULSES_PER_MM_Z = 400
 STEPPER_PULSES_PER_MM_E = 150
 
-# How long it takes the extruder to go from un-extruded to fully extruded
-# TODO calibrate
-EXTRUDER_RANGE = 1000  # seconds
-
 # Invert axises direction, by default(False) high level means increase of
 # position. For inverted(True) axis, high level means decrease of position.
 STEPPER_INVERTED_X = True
@@ -38,6 +34,7 @@ ENDSTOP_INVERTED_Z = False  # Auto leveler
 TABLE_SIZE_X_MM = 200
 TABLE_SIZE_Y_MM = 200
 TABLE_SIZE_Z_MM = 220
+EXTRUDER_LENGTH_MM = 50
 
 # Mixed settings.
 STEPPER_PULSE_LENGTH_US = 2
@@ -52,6 +49,7 @@ EXTRUDER_PID = {"P": 0.059161177519,
 BED_PID = {"P": 0.226740848076,
            "I": 0.00323956215053,
            "D": 0.323956215053}
+NUM_EXTRUDERS = 6
 
 # -----------------------------------------------------------------------------
 # Pins configuration.

--- a/cnc/gcode.py
+++ b/cnc/gcode.py
@@ -81,6 +81,8 @@ class GCode(object):
             return 'G' + self.params['G']
         if 'M' in self.params:
             return 'M' + self.params['M']
+        if 'T' in self.params:
+            return 'T'
         return None
 
     @staticmethod

--- a/cnc/hal.py
+++ b/cnc/hal.py
@@ -125,6 +125,8 @@ if 'calibrate' not in locals():
     raise NotImplementedError("hal.calibrate() not implemented")
 if 'move' not in locals():
     raise NotImplementedError("hal.move() not implemented")
+if 'get_extruder' not in locals():
+    raise NotImplementedError("hal.get_extruder() not implemented")
 if 'join' not in locals():
     raise NotImplementedError("hal.join() not implemented")
 if 'deinit' not in locals():

--- a/cnc/hal_raspberry/hal.py
+++ b/cnc/hal_raspberry/hal.py
@@ -51,12 +51,12 @@ def init():
     # Also init the extruders
     # TODO save the previous position and use that as initial position for convenience
     extruders.extend([
-        Extruder(pwm, EXTRUDER_0_PWM_PIN, EXTRUDER_RANGE),
-        Extruder(pwm, EXTRUDER_1_PWM_PIN, EXTRUDER_RANGE),
-        Extruder(pwm, EXTRUDER_2_PWM_PIN, EXTRUDER_RANGE),
-        Extruder(pwm, EXTRUDER_3_PWM_PIN, EXTRUDER_RANGE),
-        Extruder(pwm, EXTRUDER_4_PWM_PIN, EXTRUDER_RANGE),
-        Extruder(pwm, EXTRUDER_5_PWM_PIN, EXTRUDER_RANGE)
+        Extruder(pwm, EXTRUDER_0_PWM_PIN, EXTRUDER_LENGTH_MM),
+        Extruder(pwm, EXTRUDER_1_PWM_PIN, EXTRUDER_LENGTH_MM),
+        Extruder(pwm, EXTRUDER_2_PWM_PIN, EXTRUDER_LENGTH_MM),
+        Extruder(pwm, EXTRUDER_3_PWM_PIN, EXTRUDER_LENGTH_MM),
+        Extruder(pwm, EXTRUDER_4_PWM_PIN, EXTRUDER_LENGTH_MM),
+        Extruder(pwm, EXTRUDER_5_PWM_PIN, EXTRUDER_LENGTH_MM)
     ])
 
 
@@ -271,10 +271,7 @@ def move(generator):
                 pins_to_clear |= 1 << STEPPER_DIR_PIN_Z
             elif tz < 0:
                 pins_to_set |= 1 << STEPPER_DIR_PIN_Z
-            if te > 0:
-                pins_to_clear |= 1 << STEPPER_DIR_PIN_E
-            elif te < 0:
-                pins_to_set |= 1 << STEPPER_DIR_PIN_E
+            # ignore te
             dma.add_set_clear(pins_to_set, pins_to_clear)
             continue
         pins = 0
@@ -289,8 +286,7 @@ def move(generator):
             pins |= STEP_PIN_MASK_Y
         if tz is not None:
             pins |= STEP_PIN_MASK_Z
-        if te is not None:
-            pins |= STEP_PIN_MASK_E
+        # ignore te
         if k - prev > 0:
             dma.add_delay(k - prev)
         dma.add_pulse(pins, STEPPER_PULSE_LENGTH_US)

--- a/cnc/hal_virtual.py
+++ b/cnc/hal_virtual.py
@@ -8,6 +8,23 @@ from cnc.config import *
     It checks PulseGenerator with some tests.
 """
 
+class VirtualExtruder(object):
+    def __init__(self):
+        self._pos = 0
+
+    def get_position(self):
+        return self._pos
+
+    def set_position(self, position, speed=1, wait=False):
+        logging.info('set extruder to position {} at speed {}'.format(position, speed))
+        self._pos = position
+
+    def join(self):
+        pass
+
+
+extruders = [VirtualExtruder() for i in range(NUM_EXTRUDERS)]
+
 
 def init():
     """ Initialize GPIO pins and machine itself.
@@ -184,6 +201,10 @@ def move(generator):
     logging.debug("Moved {}, {}, {}, {} iterations".format(ix, iy, iz, ie))
     logging.info("prepared in " + str(round(pt - st, 2)) + "s, estimated "
                  + str(round(generator.total_time_s(), 2)) + "s")
+
+
+def get_extruder(id):
+    return extruders[id]
 
 
 def join():

--- a/tests/test_gmachine.py
+++ b/tests/test_gmachine.py
@@ -189,38 +189,6 @@ class TestGMachine(unittest.TestCase):
         m.do_command(GCode.parse_line("X1Y1Z1E1"))
         self.assertEqual(m.position(), Coordinates(1, 1, 1, 1))
 
-    def test_g53_g92(self):
-        m = GMachine()
-        m.do_command(GCode.parse_line("G92X100Y100Z100E100"))
-        m.do_command(GCode.parse_line("X101Y102Z103E104"))
-        self.assertEqual(m.position(), Coordinates(1, 2, 3, 4))
-        m.do_command(GCode.parse_line("G92X-1Y-1Z-1E-1"))
-        m.do_command(GCode.parse_line("X1Y1Z1E1"))
-        self.assertEqual(m.position(), Coordinates(3, 4, 5, 6))
-        m.do_command(GCode.parse_line("G92X3Y4Z5E6"))
-        m.do_command(GCode.parse_line("X0Y0Z0E0"))
-        self.assertEqual(m.position(), Coordinates(0, 0, 0, 0))
-        m.do_command(GCode.parse_line("X1Y2Z3E4"))
-        self.assertEqual(m.position(), Coordinates(1, 2, 3, 4))
-        m.do_command(GCode.parse_line("G53"))
-        m.do_command(GCode.parse_line("X6Y7Z8E9"))
-        self.assertEqual(m.position(), Coordinates(6, 7, 8, 9))
-        m.do_command(GCode.parse_line("G92E0"))
-        m.do_command(GCode.parse_line("X6Y7Z8E1"))
-        self.assertEqual(m.position(), Coordinates(6, 7, 8, 10))
-        m.do_command(GCode.parse_line("G92"))
-        m.do_command(GCode.parse_line("X1Y1Z1E1"))
-        self.assertEqual(m.position(), Coordinates(7, 8, 9, 11))
-
-    def test_g53_g91_g92(self):
-        m = GMachine()
-        m.do_command(GCode.parse_line("G92X-50Y-60Z-70E-80"))
-        m.do_command(GCode.parse_line("X-45Y-55Z-65E-75"))
-        self.assertEqual(m.position(), Coordinates(5, 5, 5, 5))
-        m.do_command(GCode.parse_line("G91"))
-        m.do_command(GCode.parse_line("X-1Y-2Z-3E-4"))
-        self.assertEqual(m.position(), Coordinates(4, 3, 2, 1))
-
     def test_m3_m5(self):
         m = GMachine()
         m.do_command(GCode.parse_line("M3S" + str(SPINDLE_MAX_RPM)))

--- a/tests/test_parser.gcode
+++ b/tests/test_parser.gcode
@@ -21,7 +21,6 @@ g21
 g1y1
 g1y-1
 g90
-g92x100y100z100f240
 m111
 g1x98y98z98f120
 (head should be in zero position)


### PR DESCRIPTION
This fixes the gcode to use G commands to move the extruders again instead of `M126`/`M127`. This way the extruders can move in parallel with the rest of the machine and at varying speeds. Switch extruders with the `T` comand.

This drops support for `G53` and `G92` partly because I'm not sure what they're for.

Close #10.